### PR TITLE
Update callback props

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ const BannerText = (props) => {
       initialValue={-200} // value to animate from
       finalValue={0} // value to animate to
       shouldAnimateIn // flag to start the animation
-      animateInCallBack={null} // some function to trigger once the animation has ended
+      animateInCallback={null} // some function to trigger once the animation has ended
       shouldAnimateOut={false} // flag to reverse the animation (only if shouldAnimateIn was previously set)
-      animateOutCallBack={null} // some function to trigger once the animation has ended
+      animateOutCallback={null} // some function to trigger once the animation has ended
       shouldRepeat // repeat the animation, ie. -200 => 0 and back to -200 etc.
       shouldLoop // loop the animation (must set shouldRepeat to work), ie. -200 => 0 => reset to 0 => -200 => 0 etc.
       duration={2000} // duration of the animation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-simple-animators",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "description": "A collection of simple, reusable react-native animator wrapper components",
   "main": "index.js",
   "scripts": {

--- a/src/StaticAnimator/index.js
+++ b/src/StaticAnimator/index.js
@@ -24,7 +24,9 @@ export default class StaticAnimator extends React.Component {
       shouldAnimateIn: PropTypes.bool,
       shouldAnimateOut: PropTypes.bool,
       animateInCallBack: PropTypes.func,
+      animateInCallback: PropTypes.func,
       animateOutCallBack: PropTypes.func,
+      animateOutCallback: PropTypes.func,
       shouldRepeat: PropTypes.bool,
       shouldLoop: PropTypes.bool, // used with repeat (cycles the animation instead of going back and forth)
       style: PropTypes.oneOfType([PropTypes.number, PropTypes.object, PropTypes.array]),
@@ -78,6 +80,8 @@ export default class StaticAnimator extends React.Component {
     }).start(() => {
       if (this.props.animateInCallBack) {
         this.props.animateInCallBack();
+      } else if (this.props.animateInCallback) {
+        this.props.animateInCallback();
       }
 
       if (this.props.shouldRepeat) {
@@ -103,6 +107,8 @@ export default class StaticAnimator extends React.Component {
     }).start(() => {
       if (this.props.animateOutCallBack) {
         this.props.animateOutCallBack();
+      } else if (this.props.animateOutCallback) {
+        this.props.animateOutCallback();
       }
 
       if (this.props.shouldRepeat) {


### PR DESCRIPTION
# Description

StaticAnimator now accepts animateInCallback and animateOutCallback. Note the difference in casing to the current props, animateInCallBack and animateOutCallBack.

Fixes #19 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules